### PR TITLE
Fix spm warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             path: "DropDown",
             exclude: ["Info.plist", "DropDown.h"],
             resources: [
-              .process("DropDown/resources")
+              .process("resources")
             ]
         )
     ],


### PR DESCRIPTION
Fix the SPM warning "Invalid Resource 'DropDown/resources': File not found." 

